### PR TITLE
allow configuration to avoid using primary database in on_replica

### DIFF
--- a/knockoff.gemspec
+++ b/knockoff.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activerecord', '>= 4.0.0'
   spec.add_runtime_dependency 'activesupport', '>= 4.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.14.5"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'sqlite3'
 end

--- a/lib/knockoff.rb
+++ b/lib/knockoff.rb
@@ -11,8 +11,8 @@ module Knockoff
   class << self
     attr_accessor :enabled
 
-    def on_replica(&block)
-      Base.new(:replica).run(&block)
+    def on_replica(check_transaction: true, &block)
+      Base.new(:replica, check_transaction: check_transaction).run(&block)
     end
 
     def on_primary(&block)

--- a/lib/knockoff/base.rb
+++ b/lib/knockoff/base.rb
@@ -1,7 +1,7 @@
 module Knockoff
   class Base
-    def initialize(target)
-      @target = decide_with(target)
+    def initialize(target, check_transaction: true)
+      @target = decide_with(target, check_transaction)
     end
 
     def run(&block)
@@ -10,7 +10,7 @@ module Knockoff
 
   private
 
-    def decide_with(target)
+    def decide_with(target, check_transaction)
       calculated_target =
         if Knockoff.enabled
           target
@@ -19,7 +19,9 @@ module Knockoff
         end
 
       # Don't allow setting the target to anything other than primary if we are already in a transaction
-      raise Knockoff::Error.new('on_replica cannot be used inside transaction block!') if calculated_target != :primary && inside_transaction?
+      if calculated_target != :primary && check_transaction && inside_transaction?
+        raise Knockoff::Error.new('on_replica cannot be used inside transaction block!')
+      end
       calculated_target
     end
 

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -127,5 +127,19 @@ describe Knockoff do
         end
       end
     end
+
+    context 'with non-existent primary db' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:open_transactions) { raise 'boom' }
+      end
+
+      it 'raises error by default' do
+        expect{ Knockoff.on_replica  { User.count } }.to raise_error(RuntimeError, 'boom')
+      end
+
+      it 'avoid primary when asked' do
+        expect(Knockoff.on_replica(check_transaction: false) { User.count }).to be(1)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ ENV['RACK_ENV'] = 'test'
 require 'knockoff'
 
 ActiveRecord::Base.configurations = {
-  'test' => { adapter: 'sqlite3', database: 'tmp/test_db' }
+  'test' => { 'adapter' => 'sqlite3', 'database' => 'tmp/test_db' }
 }
 
 # Setup the ENV's for replicas


### PR DESCRIPTION
We are using Knockoff in our production systems and were upgrading our primary database and surprised to see that all the requests made to the replica when the primary was cutting over failed:

```
 /app/vendor/bundle/ruby/2.3.0/gems/pg-0.21.0/lib/pg.rb:   56:in `initialize'
 /app/vendor/bundle/ruby/2.3.0/gems/pg-0.21.0/lib/pg.rb:   56:in `new'
 /app/vendor/bundle/ruby/2.3.0/gems/pg-0.21.0/lib/pg.rb:   56:in `connect'
…ctive_record/connection_adapters/postgresql_adapter.rb:  671:in `connect'
…ctive_record/connection_adapters/postgresql_adapter.rb:  217:in `initialize'
…ctive_record/connection_adapters/postgresql_adapter.rb:   37:in `new'
…ctive_record/connection_adapters/postgresql_adapter.rb:   37:in `postgresql_connection'
…record/connection_adapters/abstract/connection_pool.rb:  729:in `new_connection'
…record/connection_adapters/abstract/connection_pool.rb:  773:in `checkout_new_connection'
…record/connection_adapters/abstract/connection_pool.rb:  752:in `try_to_checkout_new_connection'
…record/connection_adapters/abstract/connection_pool.rb:  713:in `acquire_connection'
…record/connection_adapters/abstract/connection_pool.rb:  490:in `checkout'
…record/connection_adapters/abstract/connection_pool.rb:  364:in `connection'
…record/connection_adapters/abstract/connection_pool.rb:  883:in `retrieve_connection'
…erecord-5.0.4/lib/active_record/connection_handling.rb:  128:in `retrieve_connection'
…erecord-5.0.4/lib/active_record/connection_handling.rb:   91:in `connection'
…0/gems/knockoff-1.0/lib/knockoff/active_record/base.rb:   12:in `connection'
…ndle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff/base.rb:   27:in `block in inside_transaction?'
…ndle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff/base.rb:   34:in `run_on'
…ndle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff/base.rb:   27:in `inside_transaction?'
…ndle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff/base.rb:   22:in `decide_with'
…ndle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff/base.rb:    4:in `initialize'
…or/bundle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff.rb:   15:in `new'
…or/bundle/ruby/2.3.0/gems/knockoff-1.0/lib/knockoff.rb:   15:in `on_replica'
```

The use of `ActiveRecord::Base.connection.open_transactions` to check the transaction count appears to be the culprit.  I'm not really sold on the approach I have taken in this PR (nor the round-about way of testing it).  I'm open to suggestions.  But we'd like to find a way to have the replica requests be resilient to transient primary database outages.
