### PR TITLE
Decode passwords in connection URI string

### DIFF
--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -88,7 +88,7 @@ module Knockoff
                 'adapter' => adapter,
                 'database' => (uri.path || "").split("/")[1],
                 'username' => uri.user,
-                'password' => uri.password,
+                'password' => uri.password.present? ? URI.decode(uri.password) : nil,
                 'host' => uri.host,
                 'port' => uri.port
               }

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -167,6 +167,14 @@ describe Knockoff do
     end
 
     context 'passwords' do
+      before do
+        @before_value = ENV['KNOCKOFF_REPLICA1']
+      end
+
+      after do
+        ENV['KNOCKOFF_REPLICA1'] = @before_value
+      end
+
       it 'should allow simple passwords in URI' do
         ENV['KNOCKOFF_REPLICA1'] = "mysql2://user:just_regular_password@localhost/tmp/test_replica_db"
 

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -165,5 +165,31 @@ describe Knockoff do
         expect(Knockoff.on_replica(check_transaction: false) { User.count }).to be(1)
       end
     end
+
+    context 'passwords' do
+      it 'should allow simple passwords in URI' do
+        ENV['KNOCKOFF_REPLICA1'] = "mysql2://user:just_regular_password@localhost/tmp/test_replica_db"
+
+        Knockoff.config.send(:parse_knockoff_replica_envs_to_configs)
+
+        expect(ActiveRecord::Base.configurations['knockoff_replica_0']['password']).to eq "just_regular_password"
+      end
+
+      it 'should decode passwords in URI' do
+        ENV['KNOCKOFF_REPLICA1'] = "mysql2://user:%23%20'%2520*%40@localhost/tmp/test_replica_db"
+
+        Knockoff.config.send(:parse_knockoff_replica_envs_to_configs)
+
+        expect(ActiveRecord::Base.configurations['knockoff_replica_0']['password']).to eq "# '%20*@"
+      end
+
+      it 'should allow no passwords in URI' do
+        ENV['KNOCKOFF_REPLICA1'] = "mysql2://user:@localhost/tmp/test_replica_db"
+
+        Knockoff.config.send(:parse_knockoff_replica_envs_to_configs)
+
+        expect(ActiveRecord::Base.configurations['knockoff_replica_0']['password']).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Our database password contains a lot of weird characters so `URI.parse` was raising errors if we did not encode it. `URI::InvalidURIError (bad URI(is not URI?):`

The way to escape passwords in URLs is to use `URI.encode`. However, Knockoff was trying to connect with the urlencoded password string, so this fix was required. 