### PR TITLE
Fix deprecation warning on ActiveRecord versions >= 6.0

### DIFF
--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -96,10 +96,17 @@ module Knockoff
 
           # Store the hash in configuration and use it when we establish the connection later.
           key = "knockoff_replica_#{index}"
-          full_config = replica_config.merge(uri_config)
+          config = replica_config.merge(uri_config)
 
-          ActiveRecord::Base.configurations[key] = full_config
-          @replicas_configurations[key] = full_config
+          if ActiveRecord::VERSION::MAJOR >= 6
+            full_config = ActiveRecord::Base.configurations.to_h.merge(key => config)
+
+            ActiveRecord::Base.configurations = full_config
+            @replicas_configurations[key] = config
+          else
+            ActiveRecord::Base.configurations[key] = config
+            @replicas_configurations[key] = config
+          end
         rescue URI::InvalidURIError
           Rails.logger.info "LOG NOTIFIER: Invalid URL specified in follower_env_keys. Not including URI, which may result in no followers used." # URI is purposely not printed to logs
           # Return a 'nil' which will be removed from


### PR DESCRIPTION
On ActiveRecord versions >= 6.0, Knockoff prints a deprecation warning:

```
DEPRECATION WARNING: Setting `ActiveRecord::Base.configurations` with `[]=` is deprecated. 
Use `ActiveRecord::Base.configurations=` directly to set the configurations instead. 
(called from block in parse_knockoff_replica_envs_to_configs at /Users/bjreath/code/handshake/knockoff/lib/knockoff/config.rb:101)
```

This [Rails PR](https://github.com/rails/rails/pull/33637) introduced the deprecation warning, and recommends that the full `ActiveRecord::Base.configurations=` setter be used rather than the setters for individual keys.

This PR changes the behavior on Rails versions >= 6.0 to follow this recommendation.