### PR TITLE
stop swallowing blocks passed to exec_queries

### DIFF
--- a/lib/knockoff/active_record/relation.rb
+++ b/lib/knockoff/active_record/relation.rb
@@ -5,11 +5,11 @@ module ActiveRecord
     # Supports queries like User.on_replica.to_a
     alias_method :exec_queries_without_knockoff, :exec_queries
 
-    def exec_queries
+    def exec_queries(&block)
       if knockoff_target == :replica
-        Knockoff.on_replica { exec_queries_without_knockoff }
+        Knockoff.on_replica { exec_queries_without_knockoff(&block) }
       else
-        exec_queries_without_knockoff
+        exec_queries_without_knockoff(&block)
       end
     end
 


### PR DESCRIPTION
since version 5.1, `ActiveRecord::Relation#exec_queries` has taken a block argument
see https://github.com/rails/rails/commit/caa178c178468f7adcc5f4c597280e6362d9e175

the current `exec_queries_without_knockoff` call does not forward that block to the real implementation
this breaks some of ActiveRecord's internal bookkeeping; e.g. association inverses

the fix is to just pass the block along 