### PR TITLE
Add support for setting the schema cache on each replica pool

### DIFF
--- a/lib/knockoff.rb
+++ b/lib/knockoff.rb
@@ -49,6 +49,10 @@ module Knockoff
       @config ||= Config.new
     end
 
+    def set_schema_cache(cache)
+      replica_pool.set_schema_cache(cache)
+    end
+
     def base_transaction_depth
       @base_transaction_depth ||= begin
         testcase = ActiveSupport::TestCase

--- a/lib/knockoff/replica_connection_pool.rb
+++ b/lib/knockoff/replica_connection_pool.rb
@@ -30,6 +30,12 @@ module Knockoff
       end
     end
 
+    def set_schema_cache(cache)
+      @pool.each do |_name, klass|
+        klass.connection_pool.schema_cache = cache
+      end
+    end
+
     def random_replica_connection
       @pool[@pool.keys.sample]
     end

--- a/lib/knockoff/version.rb
+++ b/lib/knockoff/version.rb
@@ -1,3 +1,3 @@
 module Knockoff
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -83,6 +83,14 @@ describe Knockoff do
       end
     end
 
+    context 'setting schema cache' do
+      it 'sets the cache to each pool schema_cache value' do
+        expect(Knockoff::KnockoffReplica0.connection_pool.schema_cache).to be_nil
+        Knockoff.set_schema_cache('test')
+        expect(Knockoff::KnockoffReplica0.connection_pool.schema_cache).to eq 'test'
+      end
+    end
+
     context 'in transaction' do
       it 'raises error in transaction if replica is attempted' do
         User.transaction do


### PR DESCRIPTION
This can be used in a rails initializer to set the schema cache for the replica connection pools. For example, using the primary's connection pool schema cache value.