### PR TITLE
Allow consumers to configure the replica_environment_variable_name

### DIFF
--- a/lib/knockoff.rb
+++ b/lib/knockoff.rb
@@ -8,8 +8,11 @@ require 'knockoff/active_record/base'
 require 'knockoff/active_record/relation'
 
 module Knockoff
+  DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME = "KNOCKOFF_REPLICA_ENVS"
+  
   class << self
     attr_accessor :enabled
+    attr_accessor :replica_environment_variable_name
     attr_reader :default_target
 
     def on_replica(check_transaction: true, &block)
@@ -64,6 +67,10 @@ module Knockoff
           0
         end
       end
+    end
+
+    def replica_environment_variable_name
+      @replica_environment_variable_name ||= DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME
     end
   end
 end

--- a/lib/knockoff.rb
+++ b/lib/knockoff.rb
@@ -70,7 +70,7 @@ module Knockoff
     end
 
     def replica_environment_variable_name
-      @replica_environment_variable_name ||= DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME
+      (@replica_environment_variable_name ||= DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME).to_s
     end
   end
 end

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -26,10 +26,10 @@ module Knockoff
     end
 
     def replica_env_keys
-      if ENV['KNOCKOFF_REPLICA_ENVS'].nil?
+      if ENV[Knockoff.replica_environment_variable_name].nil?
         []
       else
-        ENV['KNOCKOFF_REPLICA_ENVS'].split(',').map(&:strip)
+        ENV[Knockoff.replica_environment_variable_name].split(',').map(&:strip)
       end
     end
 

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -24,6 +24,19 @@ describe Knockoff do
     end
   end
 
+  context 'replica_environment_variable_name' do
+    after(:each) { Knockoff.replica_environment_variable_name = Knockoff::DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME }
+
+    it 'has a default value' do
+      expect(Knockoff.replica_environment_variable_name).to eq Knockoff::DEFAULT_REPLICA_ENVIRONMENT_VARIABLE_NAME
+    end
+
+    it 'can be configured' do
+      Knockoff.replica_environment_variable_name = "CUSTOM_REPLICA_ENV_VAR"
+      expect(Knockoff.replica_environment_variable_name).to eq "CUSTOM_REPLICA_ENV_VAR"
+    end
+  end
+
   context 'enabled' do
     before(:each) { Knockoff.enabled = true }
 

--- a/spec/knockoff_spec.rb
+++ b/spec/knockoff_spec.rb
@@ -35,6 +35,11 @@ describe Knockoff do
       Knockoff.replica_environment_variable_name = "CUSTOM_REPLICA_ENV_VAR"
       expect(Knockoff.replica_environment_variable_name).to eq "CUSTOM_REPLICA_ENV_VAR"
     end
+
+    it 'is a string' do
+      Knockoff.replica_environment_variable_name = 54321
+      expect(Knockoff.replica_environment_variable_name).to eq "54321"
+    end
   end
 
   context 'enabled' do


### PR DESCRIPTION
Separate PR for failing ruby versions - https://github.com/joinhandshake/knockoff/pull/27 

**Problem:** Need to set the replica to a separate replica database in the context of a Rails Engine without overwriting the replica database for the entire application. 
For example, `my_app/config/initializers/knockoff.rb`:
```
Knockoff.replica_environment_variable_name = "APP_REPLICA_DB_URL"
```
and `my_app/my_engine/config/initializers/knockoff.rb`:
```
Knockoff.replica_environment_variable_name = "MY_ENGINE_REPLICA_DB_URL"
```

**Solution:**
Make the replica ENV variable name configurable.
By giving it a default value of the current config name, `KNOCKOFF_REPLICA_ENVS`, this is a non-breaking change.