### PR TITLE
Drop Ruby 2.4 and 2.5 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.4.0', '2.5.1', '2.6.6', '2.7.2']
+        ruby-version: ['2.6.6', '2.7.2']
 
     steps:
       # Pin to this commit: v2


### PR DESCRIPTION
bundler requires Ruby version >= 2.6.0