### PR TITLE
Refactor config to use rails 6.1 APIs

### DIFF
--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -70,6 +70,7 @@ module Knockoff
           # Configure parameters such as prepared_statements, pool, reaping_frequency for all replicas.
           ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').each do |it|
             register_replica_copy(index, env_key, it.configuration_hash)
+            break
           end
 
           if !ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').present?

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -69,7 +69,7 @@ module Knockoff
 
           # Configure parameters such as prepared_statements, pool, reaping_frequency for all replicas.
           ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').each do |it|
-            register_replica_copy(index, env_key, it)
+            register_replica_copy(index, env_key, it.configuration_hash)
           end
 
           if !ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').present?

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -35,11 +35,11 @@ module Knockoff
 
     def update_replica_configs(new_configs)
       if ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').present?
-        new_configs.deep_dup.merge!(ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').first.configuration_hash)
+        updated_config = new_configs.deep_dup.merge!(ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').first.configuration_hash)
       end
 
       @replicas_configurations.each do |key, _config|
-        update_replica_config(key, new_configs)
+        update_replica_config(key, updated_config)
       end
     end
 
@@ -52,9 +52,9 @@ module Knockoff
 
     private
 
-    def update_replica_config(key, new_configs)
-      @replicas_configurations[key].merge!(new_configs)
-      ActiveRecord::Base.configurations[key].merge!(new_configs)
+    def update_replica_config(key, updated_config)
+      @replicas_configurations[key].merge!(updated_config)
+      ActiveRecord::Base.configurations.configurations << @replicas_configurations[key]
     end
 
     def set_replica_configs

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -90,7 +90,7 @@ module Knockoff
       key = "knockoff_replica_#{index}"
       new_config = create_replica_copy(env_key, key, configuration_hash.deep_dup)
       ActiveRecord::Base.configurations.configurations << new_config
-      @replicas_configurations[key] = new_config.deep_dup
+      @replicas_configurations[key] = new_config.configuration_hash.deep_dup
     end
 
     def create_replica_copy(env_key, key, replica_config_hash)

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -53,7 +53,7 @@ module Knockoff
     private
 
     def update_replica_config(key, updated_config)
-      @replicas_configurations[key].merge!(updated_config)
+      @replicas_configurations[key] = @replicas_configurations[key].configuration_hash.deep_dup.merge!(updated_config)
       ActiveRecord::Base.configurations.configurations << @replicas_configurations[key]
     end
 
@@ -90,13 +90,11 @@ module Knockoff
       key = "knockoff_replica_#{index}"
       new_config = create_replica_copy(env_key, key, configuration_hash.deep_dup)
       ActiveRecord::Base.configurations.configurations << new_config
-      @replicas_configurations[key] = new_config.configuration_hash.deep_dup
+      @replicas_configurations[key] = new_config
     end
 
     def create_replica_copy(env_key, key, replica_config_hash)
       uri = URI.parse(ENV[env_key])
-
-      puts uri
 
       replica_config_hash[:adapter] =
         if uri.scheme == "postgres"
@@ -114,9 +112,6 @@ module Knockoff
         replica_config_hash[:host] = uri.host
         replica_config_hash[:port] = uri.port
       end
-      
-      puts (uri.path || "").split("/")[1]
-      puts replica_config_hash
 
       ActiveRecord::DatabaseConfigurations::HashConfig.new(key, key, replica_config_hash)
     end

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -35,7 +35,7 @@ module Knockoff
 
     def update_replica_configs(new_configs)
       if ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').present?
-        new_configs.symbolize_keys!.merge!(ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').first.configuration_hash)
+        new_configs.deep_dup.merge!(ActiveRecord::Base.configurations.configs_for(env_name: 'knockoff_replicas').first.configuration_hash)
       end
 
       @replicas_configurations.each do |key, _config|

--- a/lib/knockoff/config.rb
+++ b/lib/knockoff/config.rb
@@ -90,7 +90,7 @@ module Knockoff
       key = "knockoff_replica_#{index}"
       new_config = create_replica_copy(env_key, key, configuration_hash.deep_dup)
       ActiveRecord::Base.configurations.configurations << new_config
-      @replicas_configurations[key] = new_config
+      @replicas_configurations[key] = new_config.deep_dup
     end
 
     def create_replica_copy(env_key, key, replica_config_hash)


### PR DESCRIPTION
The DatabaseConfigurations is no longer a simple hash and the hash you can get from it is frozen https://github.com/rails/rails/pull/33637

This updates the config so that it correctly manipulates the databaseconfiguration object by creating modifiable duplicates of the config hash.

The tests didn't catch this because if there are no configurations from Rails then it uses an empty hash. The tests are not trying to mock the response from rails, so they use the empty hash which is no longer the same. Ideally they should be updated.